### PR TITLE
Upgrade Dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ documentation = "https://docs.rs/brute-force"
 [dependencies]
 crossbeam-channel = "0.5.0"
 crossbeam-utils = "0.8.1"
-curve25519-dalek = { version = "3.0.2", optional = true }
+curve25519-dalek = {  package = "curve25519-dalek-ng", version = "4.0.1", optional = true }
 log = "0.4.14"
 num_cpus = "1.13.0"
-rand = { version = "0.7", optional = true }
+rand = { version = "0.8.1", optional = true }
 
 [features]
 nightly = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brute-force"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Lee Bousfield <ljbousfield@gmail.com>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
Note this changes the underlying curve25519-dalek library to curve25519-dalek-ng (See https://github.com/zkcrypto/curve25519-dalek-ng#use which you may or may not want to use)